### PR TITLE
21 No reference to overloading

### DIFF
--- a/Representations/JavaFunctionRepresentation.py
+++ b/Representations/JavaFunctionRepresentation.py
@@ -93,11 +93,16 @@ class JavaFunctionRepresentation:
     
     def extract_name(self):
         """
-        This function extracts the name of the funciton from its declaration
+        This function extracts the name of the function from its declaration
         and saves it in the "name" member
         """
         
         self.name = self.declaration.split("(")[0].split(" ")[-1]
+    
+    def __eq__(self, value):
+        if isinstance(value, str):
+            return self.name == value
+        return isinstance(value, JavaFunctionRepresentation) and self.full_text == value.full_text
         
     def __init__(self, full_text: str) -> None:
         """

--- a/Representations/JavaTestRepresentation.py
+++ b/Representations/JavaTestRepresentation.py
@@ -1,0 +1,66 @@
+import re
+from Util import Regexs
+class JavaTestRepresentation:
+    class JavaVariableRepresentation:
+        def __init__(self, name: str, type: str) -> None:
+            self.name = name
+            self.type = type
+        
+        def __str__(self):
+            return f"Type: {self.type}, Name: {self.name}"
+        
+        def __eq__(self, other):
+            if isinstance(other, JavaTestRepresentation.JavaVariableRepresentation):
+                return self.name == other.name and self.type == other.type
+            return False
+            
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.variables = []
+        self.declaration = ""
+        self.extract_variables()
+        self.extract_declaration()
+        
+    def extract_variables(self) -> None:
+        """
+        Extracts the variables declared within a Java test method from the test text.
+
+        This method uses a regex to find all variable declarations in the test text and then creates a new JavaVariableRepresentation for each match, adding it to the "variables" list.
+
+        Parameters: None
+        Returns: None
+        """
+        matches = re.findall(Regexs.find_function_variable_types_from_test, self.text)
+        for match in matches:
+            var_type, var_name = match
+            self.variables.append(self.JavaVariableRepresentation(var_name, var_type))
+            
+    def extract_declaration(self) -> None: 
+        """
+        Extracts the declaration of a Java test method from the test text.
+        This method sets the 'declaration' attribute of the JavaTestRepresentation object by extracting the second line of the test text (after splitting by newline characters).
+
+        Parameters: None
+        Returns: None
+        """
+        text_lines = self.text.split("\n")
+        self.declaration = text_lines[1]
+            
+    def __eq__(self, other):
+        """
+        Checks if two JavaTestRepresentations are equal.
+
+        This method checks if two JavaTestRepresentation objects are equal by comparing their declaration and variables.
+
+        Parameters:
+            other (JavaTestRepresentation): The other JavaTestRepresentation object to compare with.
+
+        Returns:
+            bool: True if the two objects are equal, False if not.
+        """
+
+        if isinstance(other, JavaTestRepresentation):
+            return self.declaration == other.declaration and (all(var in other.variables for var in self.variables) and all(var in self.variables for var in other.variables))
+        return False
+
+

--- a/Representations/JavaTestRepresentation.py
+++ b/Representations/JavaTestRepresentation.py
@@ -18,9 +18,27 @@ class JavaTestRepresentation:
         self.text = text
         self.variables = []
         self.declaration = ""
+        self.function_name = ""
         self.extract_variables()
         self.extract_declaration()
+        self.extract_function_name()
         
+    def set_text(self, text: str) -> None:
+        self.__init__(text)
+        
+    
+    def extract_function_name(self) -> None:
+        """
+        Extracts the function name from the test text.
+        
+        This method uses a regex to find the function name in the test text and sets it to the 'function_name' attribute.
+
+        Parameters: None
+        Returns: None
+        """
+        matches = re.findall(Regexs.find_method_from_test, self.text)
+        self.function_name = matches[2] if matches else ""
+    
     def extract_variables(self) -> None:
         """
         Extracts the variables declared within a Java test method from the test text.
@@ -45,6 +63,20 @@ class JavaTestRepresentation:
         """
         text_lines = self.text.split("\n")
         self.declaration = text_lines[1]
+        
+    def get_overloaded_num_from_declaration(declaration) -> int:
+        """
+        Extracts the number of overloaded methods from a Java test method declaration.
+
+        This method counts the occurrences of the word "Overloaded" in the declaration string and returns that count.
+
+        Parameters:
+            declaration (str): The declaration string of a Java test method.
+
+        Returns:
+            int: The number of times "Overloaded" appears in the declaration.
+        """
+        return declaration.split("Overloaded")[1].index(0) if "Overloaded" in declaration else None
             
     def __eq__(self, other):
         """
@@ -60,7 +92,19 @@ class JavaTestRepresentation:
         """
 
         if isinstance(other, JavaTestRepresentation):
-            return self.declaration == other.declaration and (all(var in other.variables for var in self.variables) and all(var in self.variables for var in other.variables))
-        return False
+            overloaded_num_self = self.get_overloaded_num_from_declaration(self.declaration)
+            all_variables_equal = (all(var in other.variables for var in self.variables) and all(var in self.variables for var in other.variables))
+            if overloaded_num_self:
+                overloaded_num_other = self.get_overloaded_num_from_declaration(other.declaration)
+                if overloaded_num_other:
+                    return self.function_name == other.function_name and all_variables_equal
+            return self.declaration == other.declaration and all_variables_equal
+        overloaded_num_other = self.get_overloaded_num_from_declaration(other)
+        if overloaded_num_other:
+            return other.split("Overloaded")[0] in self.declaration # checking if other is an overloaded version of the same test
+        return other in self.declaration if isinstance(other, str) else False # if other is a string, compare with declaration directly
+    
+    def __str__(self):
+        return f"Declaration: {self.declaration}, Function Name: {self.function_name}, Variables: {[str(var) for var in self.variables]}"
 
 

--- a/Src/TestCreator.py
+++ b/Src/TestCreator.py
@@ -1,10 +1,13 @@
 from Util import Config
 from Util import Templates
+from Util import Regexs
 from Representations.JavaClassRepresentation import JavaClassRepresentation
 from Representations.JavaFunctionRepresentation import JavaFunctionRepresentation
+from Representations.JavaTestRepresentation import JavaTestRepresentation
 
 
 import os
+import re
 
 
 def capitalize_first_letter(text: str) -> str:
@@ -363,6 +366,10 @@ class TestCreator:
             result = test_class_file.read()# If there are existing tests, we will use them to create the file
             test_class_file.close()
             if result.__contains__(Templates.eof):
+                matches = re.findall(Regexs.find_tests_within_test_class, result)
+                previous_tests_list = []
+                for match in matches:
+                    previous_tests_list.append(JavaTestRepresentation(match))
                 tests = self.create_tests(existing_tests=result)
                 result = result.replace(Templates.eof, tests)
             else:

--- a/Src/TestCreator.py
+++ b/Src/TestCreator.py
@@ -75,7 +75,8 @@ def create_standard_tests_for_function(
     class_name: str,
     test_params: str,
     is_singleton: bool,
-    existing_tests: str = ""
+    overloaded_num: int = None,
+    existing_tests: list= []
 ) -> str:
     """
     Generates multiple standard test templates for a Java function.
@@ -104,6 +105,7 @@ def create_standard_tests_for_function(
             sending_params=sending_params,
             params=test_params,
             is_singleton=is_singleton,
+            overloaded_num=overloaded_num,
             existing_tests=existing_tests
         )
     return function_tests
@@ -113,7 +115,8 @@ def create_exception_throwing_tests_for_function(
     class_name: str,
     test_params: str,
     is_singleton: bool,
-    existing_tests: str = ""
+    overloaded_num: int = None,
+    existing_tests: list= []
 ) -> str:
 
     """
@@ -143,6 +146,7 @@ def create_exception_throwing_tests_for_function(
                 test_number=number,
                 params=test_params,
                 is_singleton=is_singleton,
+                overloaded_num=overloaded_num,
                 existing_tests=existing_tests
             )
     return function_tests
@@ -153,7 +157,8 @@ def create_edge_case_test_for_function(
     class_name: str,
     test_params: str,
     is_singleton: bool,
-    existing_tests: str = ""
+    overloaded_num: int = None,
+    existing_tests: list= []
 ) -> str:
     """
     Generates edge case test templates for a Java function.
@@ -187,6 +192,7 @@ def create_edge_case_test_for_function(
                 sending_params=sending_params,
                 params=test_params,
                 is_singleton=is_singleton,
+                overloaded_num=overloaded_num,                
                 existing_tests=existing_tests,
             )
 
@@ -197,7 +203,8 @@ def create_null_edge_case_test_for_function(
     class_name: str,
     test_params: str,
     is_singleton: bool,
-    existing_tests: str = ""
+    overloaded_num: int = None,
+    existing_tests: list= []
 ) -> str:
     """
     Generates edge case test templates for a Java function.
@@ -231,6 +238,7 @@ def create_null_edge_case_test_for_function(
                 params=test_params,
                 is_singleton=is_singleton,
                 param_type=param_type,
+                overloaded_num=overloaded_num,
                 existing_tests=existing_tests
             )
 
@@ -260,6 +268,69 @@ class TestCreator:
     full_text = ""
     class_representation = None
     
+    def create_tests_for_function(self,func:JavaFunctionRepresentation, existing_tests:str = "", overloaded_num=None) -> str:
+        """
+        Generates test templates for a Java function.
+
+        This method creates test templates for the given Java function, including standard tests, edge case tests, and tests for expected exceptions.
+
+        Args:
+            func (JavaFunctionRepresentation): The Java function representation object.
+            class_name (str): The name of the class containing the function.
+            test_params (str): A string containing test parameters.
+            is_singleton (bool): Indicates if the class is a Singleton.
+            existing_tests (str): Existing tests to append new tests to, if any.
+
+        Returns:
+            str: A string containing formatted Java test methods.
+        """
+        tests = ""
+        test_params = create_test_parameters(java_function=func)
+        test = create_standard_tests_for_function(
+            func=func,
+            class_name=self.class_representation.name,
+            test_params=test_params,
+            is_singleton=self.class_representation.is_singleton,
+            overloaded_num=overloaded_num,
+            existing_tests=existing_tests
+        )
+        tests += test
+
+        test_params = create_test_parameters(java_function=func)
+        test = create_edge_case_test_for_function(
+            func=func,
+            class_name=self.class_representation.name,
+            test_params=test_params,
+            is_singleton=self.class_representation.is_singleton,
+            overloaded_num=overloaded_num,
+            existing_tests=existing_tests
+        )
+        tests += test
+
+        test_params = create_test_parameters(java_function=func)
+        test = create_null_edge_case_test_for_function(
+            func=func,
+            class_name=self.class_representation.name,
+            test_params=test_params,
+            is_singleton=self.class_representation.is_singleton,
+            overloaded_num=overloaded_num,
+            existing_tests=existing_tests
+        )
+        tests += test
+            
+        test_params = create_test_parameters(java_function=func)
+        test = create_exception_throwing_tests_for_function(
+            func=func,
+            class_name=self.class_representation.name,
+            test_params=test_params,
+            is_singleton=self.class_representation.is_singleton,
+            overloaded_num=overloaded_num,
+            existing_tests=existing_tests
+        )
+        tests += test
+        
+        return tests
+    
 
     def create_tests(self, existing_tests:str = "") -> str:        
         """
@@ -272,49 +343,27 @@ class TestCreator:
             str: A string containing formatted Java test methods.
         """
         tests = ""
+        func_dic_by_name = {}
         for func in self.class_representation.functions:
-            test_params = create_test_parameters(java_function=func)
-            test = create_standard_tests_for_function(
-                func=func,
-                class_name=self.class_representation.name,
-                test_params=test_params,
-                is_singleton=self.class_representation.is_singleton,
-                existing_tests=existing_tests
-            )
-            tests += test
+            if func.name not in func_dic_by_name:
+                func_dic_by_name[func.name] = [func]
+            else:
+                func_dic_by_name[func.name].append(func)
 
-        for func in self.class_representation.functions:
-            test_params = create_test_parameters(java_function=func)
-            test = create_edge_case_test_for_function(
-                func=func,
-                class_name=self.class_representation.name,
-                test_params=test_params,
-                is_singleton=self.class_representation.is_singleton,
-                existing_tests=existing_tests
-            )
-            tests += test
-
-        for func in self.class_representation.functions:
-            test_params = create_test_parameters(java_function=func)
-            test = create_null_edge_case_test_for_function(
-                func=func,
-                class_name=self.class_representation.name,
-                test_params=test_params,
-                is_singleton=self.class_representation.is_singleton,
-                existing_tests=existing_tests
-            )
-            tests += test
-                
-        for func in self.class_representation.functions:
-            test_params = create_test_parameters(java_function=func)
-            test = create_exception_throwing_tests_for_function(
-                func=func,
-                class_name=self.class_representation.name,
-                test_params=test_params,
-                is_singleton=self.class_representation.is_singleton,
-                existing_tests=existing_tests
-            )
-            tests += test
+        for func in func_dic_by_name.values():
+            if len(func) > 1:
+                # If there are overloaded functions, we will create tests for each of them
+                for overloaded_num, overloaded_func in enumerate(func):
+                    tests += self.create_tests_for_function(
+                        func=overloaded_func,
+                        existing_tests=existing_tests,
+                        overloaded_num=overloaded_num+1
+                    )
+            else:
+                tests += self.create_tests_for_function(
+                    func=func[0], existing_tests=existing_tests
+                )
+        
                 
         return tests + Templates.eof  # Add end of file marker to the tests string
 
@@ -370,7 +419,9 @@ class TestCreator:
                 previous_tests_list = []
                 for match in matches:
                     previous_tests_list.append(JavaTestRepresentation(match))
-                tests = self.create_tests(existing_tests=result)
+                for test in previous_tests_list:
+                    print(test)
+                tests = self.create_tests(existing_tests=previous_tests_list)
                 result = result.replace(Templates.eof, tests)
             else:
                 result = self.create_test_class_from_template()

--- a/Util/Regexs.py
+++ b/Util/Regexs.py
@@ -1,7 +1,9 @@
-find_classes_declarations = r'.*class .*[{]'
-find_functions = r'.*[(].*[)].*\{[^}]*}'
-find_parameters = r'(?<=\()[^)]*(?=\))'
-find_access_type = r'public|private|protected'
-find_private_constructor = r'private\s+\w+\s*\(\)'
-find_get_instance_method = r'static\s+\w+\s+getInstance\s*\(\)'
-find_static_instance = r'private\s+static\s+\w+\s+\w+\s*;'
+find_classes_declarations = r'.*class .*[{]'# Matches class declarations in Java, e.g., "public class MyClass { ... }"
+find_functions = r'.*[(].*[)].*\{[^}]*}'# Matches function declarations in Java, e.g., "public void myFunction() { ... }"
+find_parameters = r'(?<=\()[^)]*(?=\))'# Matches function parameters in Java, e.g., "(int x, String y)"
+find_access_type = r'public|private|protected'# Matches access types in Java, e.g., "public", "private", "protected"
+find_private_constructor = r'private\s+\w+\s*\(\)'# Matches private constructor declarations, e.g., "private MyClass()"
+find_get_instance_method = r'static\s+\w+\s+getInstance\s*\(\)'# Matches static getInstance() method
+find_static_instance = r'private\s+static\s+\w+\s+\w+\s*;'# Matches static instance variable declarations, e.g., "private static MyClass instance;"
+find_function_variable_types_from_test = r'final\s+(\w+)\s+(\w+)\s*='# Matches final variable declarations in tests, e.g., "final int x = 5;"
+find_tests_within_test_class = r'@Test\s+public\s+void\s+\w+\s*\([\s\S]*?\}'# Matches @Test public void methodName() { ... }

--- a/Util/Regexs.py
+++ b/Util/Regexs.py
@@ -7,3 +7,4 @@ find_get_instance_method = r'static\s+\w+\s+getInstance\s*\(\)'# Matches static 
 find_static_instance = r'private\s+static\s+\w+\s+\w+\s*;'# Matches static instance variable declarations, e.g., "private static MyClass instance;"
 find_function_variable_types_from_test = r'final\s+(\w+)\s+(\w+)\s*='# Matches final variable declarations in tests, e.g., "final int x = 5;"
 find_tests_within_test_class = r'@Test\s+public\s+void\s+\w+\s*\([\s\S]*?\}'# Matches @Test public void methodName() { ... }
+find_method_from_test = r'\w+(?=\s*\()'# Matches method calls within tests, e.g., "myObject.myMethod()", the method name will be the third match

--- a/Util/Templates.py
+++ b/Util/Templates.py
@@ -1,6 +1,8 @@
 import platform
 import sys
 
+from Representations.JavaTestRepresentation import JavaTestRepresentation
+
 test_class_path = sys.argv[1]
 
 os_name = platform.system().lower()
@@ -66,7 +68,9 @@ def create_standard_test(
     sending_params: str,
     params: str,
     is_singleton: bool,
-    existing_tests: str = ""
+    overloaded_num: int,
+    overloaded_total: int = 0,
+    existing_tests: list= []
 ) -> str:
     """
     Generates a standard test template for a given Java function.
@@ -89,7 +93,10 @@ def create_standard_test(
         - If the function is "getInstance" or the same as the class name, an empty string is returned.
         - Handles both Singleton and non-Singleton class instantiation.
     """
-    declaration = f"public void test{function_in_name}Standard{test_number}()"
+    overload_text = f"Overloaded{overloaded_num}" if overloaded_num else ""
+
+    
+    declaration = f"public void test{function_in_name}{overload_text}Standard{test_number}()"
     # used to determine whether the test is a duplicate
 
     # returns an empty string if the function is "getInstance" or the same as the class name because we don't want to test constructors
@@ -116,7 +123,9 @@ def create_edge_case_test(
     sending_params: str,
     params: str,
     is_singleton: bool,
-    existing_tests: str = ""
+    overloaded_num: int,
+    overloaded_total: int = 0,
+    existing_tests: list= []
 ) -> str:
     """
     Generates an edge case test template for a given Java function.
@@ -141,12 +150,15 @@ def create_edge_case_test(
         - Handles both Singleton and non-Singleton class instantiation.
     """
 
+    
+    
     # returns an empty string if the function is "getInstance" or the same as the class name because we don't want to test constructors
     if java_function in ["getInstance", class_name]:
         return ""
     
+    overload_text = f"Overloaded{overloaded_num}" if overloaded_num else ""
     # used to determine whether the test is a duplicate
-    declaration = f"public void test{function_in_name}EdgeCase{param_name}{test_number}()"
+    declaration = f"public void test{function_in_name}{overload_text}EdgeCase{param_name}{test_number}()"
     
     
 
@@ -170,7 +182,9 @@ def create_null_edge_case_test(
     params: str,
     is_singleton: bool,
     param_type: str,
-    existing_tests: str = ""
+    overloaded_num: int,
+    overloaded_total: int = 0,
+    existing_tests: list= []
 ) -> str:
     """
     Generates a null edge case test template for a given Java function.
@@ -234,8 +248,10 @@ def create_null_edge_case_test(
     # replace the param name with null in the test method parameters
     sending_params = sending_params.replace(lowered_param_name, "null")
     
+    overload_text = f"Overloaded{overloaded_num}" if overloaded_num else ""
+    
     # used to determine whether the test is a duplicate
-    declaration = f"public void test{function_in_name}NullParam{param_name}{test_number}()"
+    declaration = f"public void test{function_in_name}{overload_text}NullParam{param_name}{test_number}()"
     
     return f"""
 \t@Test
@@ -255,7 +271,9 @@ def create_exception_test(
     test_number: str,
     params: str,
     is_singleton: bool,
-    existing_tests: str = "",
+    overloaded_num: int,
+    overloaded_total: int = 0,
+    existing_tests: list= [],
 ) -> str:
     """
     Generates an exception-throwing test template for a given Java function.
@@ -274,15 +292,24 @@ def create_exception_test(
     Returns:
         str: A formatted Java test method for exception throwing as a string.
     """
+    overload_text = f"Overloaded{overloaded_num}" if overloaded_num else ""
 
     # used to determine whether the test is a duplicate
-    declaration = f"public void test{function_in_name}Throws{exception}{test_number}()"
-    return f"""
+    declaration = f"public void test{function_in_name}{overload_text}Throws{exception}{test_number}()"
+    
+    
+    while True:
+        full_text = f"""
 \t@Test(expectedExceptions = {exception}.class)
 \t{declaration} {{
 {params}
 \t\t{get_instance_call(class_name, is_singleton)}().{java_function}({sending_params});
-\t}}""" if not existing_tests.__contains__(declaration) else ""
+\t}}"""
+        test = JavaTestRepresentation(full_text)
+        if declaration in existing_tests and test not in existing_tests:
+            break
+        overloaded_num += 1
+    return full_text if not existing_tests.__contains__(test) else ""
 
 # templates - were originally meant to be used directly but are now used as examples for the functions above
 standard_test = """\t@Test


### PR DESCRIPTION
Closes #21 

Feature - Add reference to overloading:
-
 - Creating a class to represent Java unit tests
 - Parsing previous tests into instances of the class that represents them
 - Overriding the comparison function of them to compare both the test's declaration and the parameters it'll send to the tested method to avoid conflating between overloaded functions
 - Overriding the comparison function of the Java function representation class to compare names to allow for differential test creation